### PR TITLE
Basic NPC behaviour

### DIFF
--- a/data/maps/main.tmx
+++ b/data/maps/main.tmx
@@ -123,7 +123,7 @@
  </layer>
  <objectgroup id="8" name="Collisions">
   <object id="6" x="80.7734" y="112.137" width="46.4017" height="47.4758"/>
-  <object id="7" x="337.272" y="111.923" width="45.9721" height="47.9055"/>
+  <object id="7" x="337.272" y="112.1" width="45.9721" height="47.8"/>
   <object id="8" x="432.653" y="207.089" width="47.0462" height="48.5499"/>
   <object id="30" x="64.3333" y="336.667" width="351.333" height="62.6667"/>
   <object id="31" x="48" y="368.364" width="16" height="31.4545"/>

--- a/src/level.py
+++ b/src/level.py
@@ -18,7 +18,7 @@ from src.sprites import (
     Tree,
     Sprite,
     Player,
-    NPC,
+    NPC, NPCBehaviourMethods,
 )
 from src.settings import (
     TILE_SIZE,
@@ -181,7 +181,7 @@ class Level:
             self.entities[obj.name] = Player(
                 pos=(obj.x * SCALE_FACTOR, obj.y * SCALE_FACTOR),
                 frames=character_frames['rabbit'],
-                groups=(self.all_sprites,),
+                groups=(self.all_sprites, self.collision_sprites),
                 collision_sprites=self.collision_sprites,
                 apply_tool=self.apply_tool,
                 interact=self.interact,
@@ -190,14 +190,16 @@ class Level:
             )
 
         # non-playable entities
+        NPCBehaviourMethods.init()
         self.npcs = {}
         for obj in tmx_maps['main'].get_layer_by_name('NPCs'):
             self.npcs[obj.name] = NPC(
                 pos=(obj.x * SCALE_FACTOR, obj.y * SCALE_FACTOR),
                 frames=character_frames['rabbit'],
-                groups=(self.all_sprites,),
+                groups=(self.all_sprites, self.collision_sprites),
                 collision_sprites=self.collision_sprites,
                 apply_tool=self.apply_tool,
+                soil_layer=self.soil_layer,
                 pf_matrix=self.pf_matrix,
                 pf_grid=self.pf_grid,
                 pf_finder=self.pf_finder,

--- a/src/npc_behaviour.py
+++ b/src/npc_behaviour.py
@@ -1,0 +1,141 @@
+import random
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TypeVar
+
+
+@dataclass
+class Context(ABC):
+    pass
+
+
+ContextType = TypeVar("ContextType", bound=Context)
+
+
+class Node(ABC):
+    """
+    Base class for all nodes on the behaviour tree.
+    """
+    @abstractmethod
+    def run(self, context: ContextType | None):
+        pass
+
+
+class Composite(Node, ABC):
+    children: list[Node]
+
+    def __init__(self, children: list[Node] = None):
+        """
+        Base class for all composite nodes.
+        :param children: List of nodes to compose
+        """
+        self.children = children or []
+
+
+class Sequence(Composite):
+    """
+    Returns false on first child failure, true if all children succeed.
+    """
+    def run(self, context: ContextType | None):
+        for child in self.children:
+            if not child.run(context):
+                return False
+        return True
+
+
+class Selector(Composite):
+    """
+    Returns true on first child success, false if all children fail.
+    """
+    def run(self, context: ContextType | None):
+        for child in self.children:
+            if child.run(context):
+                return True
+        return False
+
+
+def weighted_shuffle(children: list[tuple[int, Node]]) -> list[Node]:
+    """
+    https://softwareengineering.stackexchange.com/a/344274
+    https://utopia.duth.gr/%7Epefraimi/research/data/2007EncOfAlg.pdf
+    """
+    order = sorted(range(len(children)), key=lambda i: random.random() ** (1.0 / children[i][0]))
+    return [children[i][1] for i in order]
+
+
+class RandomComposite(Node, ABC):
+    children: list[tuple[int, Node]]
+
+    def __init__(self, children: list[tuple[int, Node]] = None):
+        """
+        Base class for all random composite nodes.
+        :param children: List of tuples containing weight and child
+        """
+        self.children = children or []
+
+
+class RandomSelector(RandomComposite):
+    """
+    Returns true on first child success, false if all children fail.
+    Children are shuffled prior to execution based on their weights.
+    """
+    def run(self, context: ContextType | None):
+        for child in weighted_shuffle(self.children):
+            if child.run(context):
+                return True
+        return False
+
+
+class Decorator(Node, ABC):
+    child: Node
+
+    def __init__(self, child: Node):
+        """
+        Base class for all decorator nodes.
+        :param child: Node to decorate
+        """
+        self.child = child
+
+
+class Inverter(Decorator):
+    """
+    Inverts its child return value.
+    """
+    def run(self, context: ContextType | None):
+        return not self.child.run(context)
+
+
+class Leaf(Node, ABC):
+    """
+    Base class for all leaf nodes.
+    """
+    pass
+
+
+class Condition(Leaf):
+    condition_func: Callable[[ContextType], bool]
+
+    def __init__(self, condition_func: Callable[[ContextType], bool]):
+        """
+        Runs the given condition function.
+        :param condition_func: Callable[[ContextType], bool]
+        """
+        self.condition_func = condition_func
+
+    def run(self, context: ContextType | None):
+        return self.condition_func(context)
+
+
+class Action(Leaf):
+    action_func: Callable[[ContextType], bool]
+
+    def __init__(self, action_func: Callable[[ContextType], bool]):
+        """
+        Runs the given action function.
+        :param action_func: Callable[[ContextType], bool]
+        """
+        self.action_func = action_func
+
+    def run(self, context: ContextType | None):
+        return self.action_func(context)

--- a/src/soil.py
+++ b/src/soil.py
@@ -98,8 +98,7 @@ class SoilLayer:
                     self.grid[y][x].append('P')
                     Plant(seed,
                           [self.all_sprites,
-                           self.plant_sprites,
-                           self.collision_sprites],
+                           self.plant_sprites],
                           soil_sprite,
                           self.level_frames[seed],
                           self.check_watered)

--- a/src/sprites.py
+++ b/src/sprites.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import IntEnum
 from typing import Callable
 
@@ -9,6 +10,8 @@ from pathfinding.core.grid import Grid as PF_Grid
 from pathfinding.finder.a_star import AStarFinder as PF_AStarFinder
 
 from src import settings
+from src.npc_behaviour import Selector, Sequence, Condition, Action
+from src.npc_behaviour import Context as BehaviourContext
 from src.settings import (
     APPLE_POS,
     GROW_SPEED,
@@ -181,7 +184,7 @@ class WaterDrop(Sprite):
             self.rect.topleft += self.direction * self.speed * dt
 
 
-class Entity(ABC, CollideableSprite):
+class Entity(CollideableSprite, ABC):
     def __init__(
             self,
             pos: settings.Coordinate,
@@ -226,14 +229,16 @@ class Entity(ABC, CollideableSprite):
 
         # inventory
         self.inventory = {
-            'wood': 20,
-            'apple': 20,
-            'corn': 20,
-            'tomato': 20,
-            'tomato seed': 5,
-            'corn seed': 5,
+            'wood': 0,
+            'apple': 0,
+            'corn': 0,
+            'tomato': 0,
+            'tomato seed': 0,
+            'corn seed': 0,
         }
-        self.money = 200
+
+        # Not all Entities can go to the market, so those that can't should not have money either
+        self.money = 0
 
     def get_state(self):
         self.state = 'walk' if self.direction else 'idle'
@@ -259,19 +264,37 @@ class Entity(ABC, CollideableSprite):
     def move(self, dt):
         pass
 
-    def collision(self, direction):
+    # FIXME: Sometimes NPCs get stuck inside the player's hitbox
+    def collision(self, direction) -> bool:
+        """
+        :return: true: Entity collides with a sprite in self.collision_sprites, otherwise false
+        """
+        colliding_rect = False
+
         for sprite in self.collision_sprites:
-            if sprite.rect.colliderect(self.hitbox_rect):
-                if direction == 'horizontal':
-                    if self.direction.x > 0:
-                        self.hitbox_rect.right = sprite.rect.left
-                    if self.direction.x < 0:
-                        self.hitbox_rect.left = sprite.rect.right
-                else:
-                    if self.direction.y < 0:
-                        self.hitbox_rect.top = sprite.rect.bottom
-                    if self.direction.y > 0:
-                        self.hitbox_rect.bottom = sprite.rect.top
+            if sprite is not self:
+
+                # Entities should collide with their hitbox_rects to make them able to approach
+                #  each other further than the empty space on their sprite images would allow
+                if isinstance(sprite, Entity):
+                    if sprite.hitbox_rect.colliderect(self.hitbox_rect):
+                        colliding_rect = sprite.hitbox_rect
+                elif sprite.rect.colliderect(self.hitbox_rect):
+                    colliding_rect = sprite.rect
+
+                if colliding_rect:
+                    if direction == 'horizontal':
+                        if self.direction.x > 0:
+                            self.hitbox_rect.right = colliding_rect.left
+                        if self.direction.x < 0:
+                            self.hitbox_rect.left = colliding_rect.right
+                    else:
+                        if self.direction.y < 0:
+                            self.hitbox_rect.top = colliding_rect.bottom
+                        if self.direction.y > 0:
+                            self.hitbox_rect.bottom = colliding_rect.top
+
+        return bool(colliding_rect)
 
     def animate(self, dt):
         current_animation = self.frames[self.state][self.facing_direction]
@@ -311,6 +334,252 @@ class Entity(ABC, CollideableSprite):
         self.animate(dt)
 
 
+# <editor-fold desc="NPC">
+@dataclass
+class NPCBehaviourContext(BehaviourContext):
+    npc: "NPC"
+
+
+# TODO: NPCs can not harvest fully grown crops on their own yet
+class NPCBehaviourMethods:
+    """
+    Group of classes used for NPC behaviour.
+
+    Attributes:
+        behaviour:   Default NPC behaviour tree
+    """
+    behaviour = None
+
+    @staticmethod
+    def init():
+        """
+        Initialises the behaviour tree.
+        """
+        NPCBehaviourMethods.behaviour = Selector([
+            Sequence([
+                Condition(NPCBehaviourMethods.will_farm),
+                Selector([
+                    Sequence([
+                        Condition(NPCBehaviourMethods.will_create_new_farmland),
+                        Action(NPCBehaviourMethods.create_new_farmland)
+                    ]),
+                    Sequence([
+                        Condition(NPCBehaviourMethods.will_plant_tilled_farmland),
+                        Action(NPCBehaviourMethods.plant_random_seed)
+                    ]),
+                    Action(NPCBehaviourMethods.water_farmland)
+                ])
+            ]),
+            Action(NPCBehaviourMethods.wander)
+        ])
+
+    @staticmethod
+    def will_farm(context: NPCBehaviourContext) -> bool:
+        """
+        1 in 3 chance to go farming instead of wandering around
+        :return: 1/3 true | 2/3 false
+        """
+        return random.randint(0, 2) is 0
+
+    @staticmethod
+    def will_create_new_farmland(context: NPCBehaviourContext) -> bool:
+        """
+        :return: True: untilled farmland available AND (all other farmland planted and watered OR 1/3), otherwise False
+        """
+        empty_farmland_available = 0
+        unplanted_farmland_available = 0
+        unwatered_farmland_available = 0
+        for y in range(len(context.npc.soil_layer.grid)):
+            for x in range(len(context.npc.soil_layer.grid[y])):
+                entry = context.npc.soil_layer.grid[y][x]
+                if "F" in entry:
+                    if "X" not in entry:
+                        empty_farmland_available += 1
+                    else:
+                        if "P" not in entry:
+                            unplanted_farmland_available += 1
+                        else:
+                            if "W" not in entry:
+                                unwatered_farmland_available += 1
+
+        if empty_farmland_available <= 0:
+            return False
+
+        return (unplanted_farmland_available == 0 and unwatered_farmland_available == 0) or random.randint(0, 2) == 0
+
+    @staticmethod
+    def create_new_farmland(context: NPCBehaviourContext) -> bool:
+        """
+        Finds a random untilled but farmable tile, makes the NPC walk to and till it.
+        :return: True if path has successfully been created, otherwise False
+        """
+        possible_coordinates = []
+        for y in range(len(context.npc.soil_layer.grid)):
+            for x in range(len(context.npc.soil_layer.grid[y])):
+                entry = context.npc.soil_layer.grid[y][x]
+                if "F" in entry and "X" not in entry:
+                    possible_coordinates.append((x, y))
+
+        if not possible_coordinates:
+            return False
+
+        def on_path_completion():
+            context.npc.tool_active = True
+            context.npc.current_tool = "hoe"
+            context.npc.frame_index = 0
+
+        return NPCBehaviourMethods.wander_to_interact(
+            context, random.choice(possible_coordinates), on_path_completion
+        )
+
+    @staticmethod
+    def will_plant_tilled_farmland(context: NPCBehaviourContext) -> bool:
+        """
+        :return: True if unplanted farmland available AND (all other farmland watered OR 3/4), otherwise False
+        """
+        unplanted_farmland_available = 0
+        unwatered_farmland_available = 0
+        for y in range(len(context.npc.soil_layer.grid)):
+            for x in range(len(context.npc.soil_layer.grid[y])):
+                entry = context.npc.soil_layer.grid[y][x]
+                if "X" in entry:
+                    if "P" not in entry:
+                        unplanted_farmland_available += 1
+                    else:
+                        if "W" not in entry:
+                            unwatered_farmland_available += 1
+
+        if unplanted_farmland_available <= 0:
+            return False
+
+        return unwatered_farmland_available == 0 or random.randint(0, 3) <= 2
+
+    @staticmethod
+    def plant_random_seed(context: NPCBehaviourContext) -> bool:
+        """
+        Finds a random unplanted but tilled tile, makes the NPC walk to and plant a random seed on it.
+        :return: True if path has successfully been created, otherwise False
+        """
+        possible_coordinates = []
+        for y in range(len(context.npc.soil_layer.grid)):
+            for x in range(len(context.npc.soil_layer.grid[y])):
+                entry = context.npc.soil_layer.grid[y][x]
+                if "X" in entry and "P" not in entry:
+                    possible_coordinates.append((x, y))
+
+        if not possible_coordinates:
+            return False
+
+        def on_path_completion():
+            context.npc.use_tool("seed")
+
+        return NPCBehaviourMethods.wander_to_interact(
+            context, random.choice(possible_coordinates), on_path_completion
+        )
+
+    # FIXME: When NPCs water the plants, the hoe is displayed as the item used instead of the watering can
+    @staticmethod
+    def water_farmland(context: NPCBehaviourContext) -> bool:
+        """
+        Finds a random unwatered but planted tile, makes the NPC walk to and water it.
+        :return: True if path has successfully been created, otherwise False
+        """
+        possible_coordinates = []
+        for y in range(len(context.npc.soil_layer.grid)):
+            for x in range(len(context.npc.soil_layer.grid[y])):
+                entry = context.npc.soil_layer.grid[y][x]
+                if "P" in entry and "W" not in entry:
+                    possible_coordinates.append((x, y))
+
+        if not possible_coordinates:
+            return False
+
+        def on_path_completion():
+            context.npc.tool_active = True
+            context.npc.current_tool = "water"
+            context.npc.frame_index = 0
+
+        return NPCBehaviourMethods.wander_to_interact(
+            context, random.choice(possible_coordinates), on_path_completion
+        )
+
+    @staticmethod
+    def wander_to_interact(context: NPCBehaviourContext,
+                           target_position: tuple[int, int],
+                           on_path_completion: Callable[[], None]):
+        """
+        :return: True if path has successfully been created, otherwise False
+        """
+
+        if context.npc.create_path_to_tile(target_position):
+            if len(context.npc.pf_path) > 1:
+                facing = (context.npc.pf_path[-1][0] - context.npc.pf_path[-2][0],
+                          context.npc.pf_path[-1][1] - context.npc.pf_path[-2][1])
+            else:
+                facing = (context.npc.pf_path[-1][0] - context.npc.rect.centerx / 64,
+                          context.npc.pf_path[-1][1] - context.npc.rect.centery / 64)
+
+            facing = (facing[0], 0) if abs(facing[0]) > abs(facing[1]) else (0, facing[1])
+
+            # Deleting the final step of the path leads to the NPC always standing in reach of the tile they want to
+            #  interact with (cf. Entity.get_target_pos)
+            context.npc.pf_path.pop(-1)
+
+            def inner():
+                context.npc.direction.update(facing)
+                context.npc.get_facing_direction()
+                context.npc.direction.update((0, 0))
+
+                on_path_completion()
+
+                context.npc.pf_on_path_completion = lambda: None
+
+            context.npc.pf_on_path_completion = inner
+            return True
+        return False
+
+    @staticmethod
+    def wander(context: NPCBehaviourContext) -> bool:
+        """
+        Makes the NPC wander to a random location in a 5 tile radius.
+        :return: True if path has successfully been created, otherwise False
+        """
+        tile_size = settings.SCALE_FACTOR * 16
+
+        # current NPC position on the tilemap
+        tile_coord = pygame.Vector2(context.npc.rect.centerx, context.npc.rect.centery) / tile_size
+
+        # To limit the required computing power, the NPC currently only tries to navigate to
+        #  11 random points in its immediate vicinity (5 tile radius)
+        avail_x_coords = list(range(
+            max(0, int(tile_coord.x) - 5),
+            min(int(tile_coord.x) + 5, context.npc.pf_grid.width - 1) + 1
+        ))
+
+        avail_y_coords = list(range(
+            max(0, int(tile_coord.y) - 5),
+            min(int(tile_coord.y) + 5, context.npc.pf_grid.height - 1) + 1
+        ))
+
+        for i in range(min(len(avail_x_coords), len(avail_y_coords))):
+            pos = (
+                random.choice(avail_x_coords),
+                random.choice(avail_y_coords)
+            )
+            avail_x_coords.remove(pos[0])
+            avail_y_coords.remove(pos[1])
+
+            if context.npc.create_path_to_tile(pos):
+                break
+        else:
+            context.npc.pf_state = NPCState.IDLE
+            context.npc.direction.update((0, 0))
+            context.npc.pf_state_duration = 1
+            return False
+        return True
+
+
+# TODO: Refactor NPCState into Entity.state (maybe override Entity.get_state())
 class NPCState(IntEnum):
     IDLE = 0
     MOVING = 1
@@ -332,6 +601,8 @@ class NPC(Entity):
        Each tile on which the NPC is moving is represented by its own coordinate tuple,
        while the first one in the list always being the NPCs current target position."""
 
+    pf_on_path_completion: Callable[[], None]
+
     def __init__(
             self,
             pos: settings.Coordinate,
@@ -339,9 +610,12 @@ class NPC(Entity):
             groups: tuple[pygame.sprite.Group],
             collision_sprites: pygame.sprite.Group,
             apply_tool: Callable,
+            soil_layer,
             pf_matrix: list[list[int]],
             pf_grid: PF_Grid,
             pf_finder: PF_AStarFinder):
+
+        self.soil_layer = soil_layer
 
         self.pf_matrix = pf_matrix
         self.pf_grid = pf_grid
@@ -349,15 +623,64 @@ class NPC(Entity):
         self.pf_state = NPCState.IDLE
         self.pf_state_duration = 0
         self.pf_path = []
+        self.pf_on_path_completion = lambda: None
 
         super().__init__(
             pos,
             frames,
             groups,
             collision_sprites,
-            (44 * SCALE_FACTOR, 40 * SCALE_FACTOR),
+
+            (32 * SCALE_FACTOR, 32 * SCALE_FACTOR),
+            # scales the hitbox down to the exact tile size
+
             apply_tool
         )
+
+        self.speed = 150
+
+        # TODO: Ensure that the NPC always has all needed seeds it needs in its inventory
+        self.inventory = {
+            'wood': 0,
+            'apple': 0,
+            'corn': 0,
+            'tomato': 0,
+            'tomato seed': 999,
+            'corn seed': 999,
+        }
+
+    def create_path_to_tile(self, coord: tuple[int, int]) -> bool:
+        if not self.pf_grid.walkable(coord[0], coord[1]):
+            return False
+
+        tile_size = settings.SCALE_FACTOR * 16
+
+        # current NPC position on the tilemap
+        tile_coord = pygame.Vector2(self.rect.centerx, self.rect.centery) / tile_size
+
+        self.pf_state = NPCState.MOVING
+        self.pf_state_duration = 0
+
+        self.pf_grid.cleanup()
+
+        start = self.pf_grid.node(int(tile_coord.x), int(tile_coord.y))
+        end = self.pf_grid.node(*[int(i) for i in coord])
+
+        path_raw = self.pf_finder.find_path(start, end, self.pf_grid)
+
+        # The first position in the path will always be removed as it is the same coordinate the NPC is already
+        #  standing on. Otherwise, if the NPC is just standing a little bit off the center of its current coordinate, it
+        #  may turn around quickly once it reaches it, if the second coordinate of the path points in the same direction
+        #  as where the NPC was just standing.
+        self.pf_path = [(i.x + .5, i.y + .5) for i in path_raw[0][1:]]
+
+        if not self.pf_path:
+            self.pf_state = NPCState.IDLE
+            self.direction.update((0, 0))
+            self.pf_state_duration = 1
+            return False
+
+        return True
 
     def move(self, dt):
         tile_size = settings.SCALE_FACTOR * 16
@@ -369,50 +692,19 @@ class NPC(Entity):
             self.pf_state_duration -= dt
 
             if self.pf_state_duration <= 0:
-                self.pf_state = NPCState.MOVING
-                self.pf_state_duration = 0
-
-                # To limit the required computing power, the NPC currently only tries to navigate to
-                #  11 random points in its immediate vicinity (5 tile radius)
-                avail_x_coords = list(range(
-                    max(0, int(tile_coord.x) - 5),
-                    min(int(tile_coord.x) + 5, self.pf_grid.width - 1) + 1
-                ))
-
-                avail_y_coords = list(range(
-                    max(0, int(tile_coord.y) - 5),
-                    min(int(tile_coord.y) + 5, self.pf_grid.height - 1) + 1
-                ))
-
-                target_pos = tuple(tile_coord)
-
-                for i in range(min(len(avail_x_coords), len(avail_y_coords))):
-                    pos = (
-                        random.choice(avail_x_coords),
-                        random.choice(avail_y_coords)
-                    )
-                    avail_x_coords.remove(pos[0])
-                    avail_y_coords.remove(pos[1])
-
-                    if self.pf_grid.walkable(pos[0], pos[1]):
-                        target_pos = pos
-                        break
-
-                self.pf_grid.cleanup()
-
-                start = self.pf_grid.node(int(tile_coord.x), int(tile_coord.y))
-                end = self.pf_grid.node(*[int(i) for i in target_pos])
-
-                path_raw = self.pf_finder.find_path(start, end, self.pf_grid)
-
-                self.pf_path = [(i.x + .5, i.y + .5) for i in path_raw[0]]
-
-                if not self.pf_path:
-                    self.pf_state = NPCState.IDLE
-                    self.direction.update((0, 0))
-                    self.pf_state_duration = 2
+                NPCBehaviourMethods.behaviour.run(NPCBehaviourContext(self))
 
         if self.pf_state == NPCState.MOVING:
+            if not self.pf_path:
+                # runs in case the path has been emptied in the meantime
+                #  (e.g. NPCBehaviourMethods.wander_to_interact created a path to a tile adjacent to the NPC)
+                self.pf_state = NPCState.IDLE
+                self.direction.update((0, 0))
+                self.pf_state_duration = random.randint(2, 5)
+
+                self.pf_on_path_completion()
+                return
+
             next_position = (tile_coord.x, tile_coord.y)
 
             # remaining distance the npc moves in the current frame
@@ -428,6 +720,8 @@ class NPC(Entity):
                     self.pf_state = NPCState.IDLE
                     self.direction.update((0, 0))
                     self.pf_state_duration = random.randint(2, 5)
+
+                    self.pf_on_path_completion()
                     break
 
                 # x- and y-distances from the NPCs current position to its target position
@@ -448,25 +742,37 @@ class NPC(Entity):
                         next_position[1] + dy * remaining_distance / distance
                     )
                     remaining_distance = 0
-                    self.direction.update((dx / distance, dy / distance))
 
-            # TODO: NPC <-> Player collision
+                    # Rounding the direction leads to smoother animations,
+                    #  e.g. if the distance vector was (-0.99, -0.01), the NPC would face upwards, although it moves
+                    #  much more to the left than upwards, as the animation method favors vertical movement
+                    #
+                    # Maybe normalise the vector?
+                    #  Currently, it is not necessary as the NPC is not moving diagonally yet,
+                    #  unless it collides with another entity while it is in-between two coordinates
+                    self.direction.update((round(dx / distance), round(dy / distance)))
 
             self.hitbox_rect.update((
                 next_position[0] * tile_size - self.hitbox_rect.width / 2,
                 self.hitbox_rect.top,
             ), self.hitbox_rect.size)
-            self.collision('horizontal')
+            colliding = self.collision('horizontal')
 
             self.hitbox_rect.update((
                 self.hitbox_rect.left,
                 next_position[1] * tile_size - self.hitbox_rect.height / 2
             ), self.hitbox_rect.size)
-            self.collision('vertical')
+            colliding = colliding or self.collision('vertical')
+
+            if colliding:
+                self.pf_state = NPCState.IDLE
+                self.direction.update((0, 0))
+                self.pf_state_duration = 1
 
         self.rect.update((self.hitbox_rect.centerx - self.rect.width / 2,
                           self.hitbox_rect.centery - self.rect.height / 2), self.rect.size)
         self.plant_collide_rect.center = self.hitbox_rect.center
+# </editor-fold>
 
 
 class Player(Entity):
@@ -501,6 +807,17 @@ class Player(Entity):
         # menus
         self.pause_menu = PauseMenu(self.font)
         self.settings_menu = SettingsMenu(self.font, self.sounds)
+
+        # inventory
+        self.inventory = {
+            'wood': 20,
+            'apple': 20,
+            'corn': 20,
+            'tomato': 20,
+            'tomato seed': 5,
+            'corn seed': 5,
+        }
+        self.money = 200
 
         # sounds
         self.sounds = sounds


### PR DESCRIPTION
A base implementation for NPC behaviour.
The two NPCs previously wandering around will now try to till, plant and water farmable tiles.
They now also collide with the Player and with other NPCs.

Known bugs:
- Sometimes NPCs get stuck inside the Player's hitbox
- When NPCs water the plants, the hoe is displayed as the item used instead of the watering can